### PR TITLE
Introduce Cloud Build for CD

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+  - name: "gcr.io/cloud-builders/npm"
+    args: ["install"]
+  - name: "gcr.io/$PROJECT_ID/firebase"
+    args:
+      ["deploy", "--project", "$PROJECT_ID", "--token", "${_FIREBASE_TOKEN}"]

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,12 @@
+Images for Cloud Build
+======================
+
+[firebase](./firebase)
+----------------------
+
+firebase image used in project's [cloudbuild.yaml](../cloudbuild.yaml)
+
+```
+cd firebase
+gcloud builds submit --project $PROJECT --config=cloudbuild.yaml .
+```

--- a/images/firebase/Dockerfile
+++ b/images/firebase/Dockerfile
@@ -1,0 +1,6 @@
+# use latest Node LTS (Carbon)
+FROM node:carbon
+# install Firebase CLI
+RUN npm install -g firebase-tools
+
+ENTRYPOINT ["/usr/local/bin/firebase"]

--- a/images/firebase/cloudbuild.yaml
+++ b/images/firebase/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+  - name: "gcr.io/cloud-builders/docker"
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/firebase", "."]
+images:
+  - "gcr.io/$PROJECT_ID/firebase"


### PR DESCRIPTION
## 概要

デプロイに [Cloud Build](https://cloud.google.com/cloud-build/?hl=ja) を使うようにします。

- master にマージされると staging にデプロイ
  - https://stage.satsukita-andon.com/
- タグがつけられると production にデプロイ
  - https://next.satsukita-andon.com/ (ある程度出来上がったら https://satsukita-andon.com に差し替えるつもり)

という感じにする予定

## モチベーション

- インフラ触らなくてもデプロイできるようにしたい
- Cloud Build を触ってみたい

## Q&A

- 他の無料サービスで十分なのでは？
  - Cloud Build を使ってみたかった…
- 不具合があったときの切り戻し
  - 手動デプロイで…
  - もしくは昔のバージョンで新しくタグを打つ、で…