### PR TITLE
Fix: translate to commonjs modules instead of esm

### DIFF
--- a/src/functions/tsconfig.json
+++ b/src/functions/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "module": "commonjs",
     "lib": ["es2015", "es2016", "es2017"],
     "typeRoots": ["../../node_modules/@types"],
     "outDir": "../../dist/functions"


### PR DESCRIPTION
firebase functions は node6 なので esm 形式は使えませんでした 😢 