### PR TITLE
Use GitHub Actions instead of Travis CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 name: ci
+
 on: [push, pull_request]
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: npm run check
+      - run: npm run type-check
       - run: npm run lint
       - run: npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,10 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: npm run check
+      - run: npm run lint
+      - run: npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: npm i
       - run: npm run type-check
       - run: npm run lint
       - run: npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          # see: https://github.com/actions/cache/blob/main/examples.md#macos-and-ubuntu
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - run: npm i
       - run: npm run type-check
       - run: npm run lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - run: npm i
+      - run: npm ci
       - run: npm run type-check
       - run: npm run lint
       - run: npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
       - uses: actions/cache@v2
         with:
           # see: https://github.com/actions/cache/blob/main/examples.md#macos-and-ubuntu

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '12' # for firebase functions
       - uses: actions/cache@v2
         with:
           # see: https://github.com/actions/cache/blob/main/examples.md#macos-and-ubuntu

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - node
-  - lts/*
-script:
-  - npm run type-check && npm run lint
-  - npm run build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 行灯職人への道 - https://satsukita-andon.com
 
-[![Build Status](https://travis-ci.org/tousetsukai/satsukita-andon.com.svg?branch=master)](https://travis-ci.org/tousetsukai/satsukita-andon.com)
+![ci](https://github.com/tousetsukai/satsukita-andon.com/workflows/ci/badge.svg)
 
 行灯職人への道 (satsukita-andon.com) is a website to record and support _andon-gyoretsu_ (行灯行列), which is one of the most exciting events of Sapporo-Kita High School (札幌北高校).
 


### PR DESCRIPTION
- Travis CI をやめて GitHub Actions にしました
  - 無料ではなくなる？ため
  - .com と .org があっていつもよくわからなくなるため
  - GitHub Actions であれば org に入っていればみんないじれるため
  - 将来的に Cloud Build もやめて GitHub Actions に一本化しようと思っているのですが、思いの外変更が大きくなりそうだったのでとりあえずここまでで PR を出します
